### PR TITLE
object literals set needsBrackets = true

### DIFF
--- a/src/grammar.jison
+++ b/src/grammar.jison
@@ -366,8 +366,8 @@ ArrayLiteral
     ;
 
 ObjectLiteral
-    : "<<" ">>"                                                             { $$ = AST.createNode(lc(@1), 'node_op', 'op_emptyobject', {}); }
-    | "<<" PropertyList ">>"                                                { $$ = AST.createNode(lc(@1), 'node_op', 'op_proplst_val', $2); }
+    : "<<" ">>"                                                             { $$ = AST.createNode(lc(@1), 'node_op', 'op_emptyobject', {}); $$.needsBrackets = true; }
+    | "<<" PropertyList ">>"                                                { $$ = AST.createNode(lc(@1), 'node_op', 'op_proplst_val', $2); $$.needsBrackets = true; }
     ;
 
 PropertyList


### PR DESCRIPTION
When compiling a JessieCode AST to javascript, object literals must have
the `needsBrackets` attribute set so that they're enclosed with curly
braces.

For example, this JessieCode:

    a = <<x: 1>>;

should produce the following JS:

    $jc$.scopes[0].locals['a'] = {
    x: 1
    }