### PR TITLE
evaluate 'null' correctly

### DIFF
--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -1451,7 +1451,11 @@ define([
                 break;
 
             case 'node_const':
-                ret = Number(node.value);
+                if(node.value === null) {
+                    ret = null;
+                } else {
+                    ret = Number(node.value);
+                }
                 break;
 
             case 'node_const_bool':


### PR DESCRIPTION
The atom 'null' is parsed as a 'node_const' node. When these were executed, they were run through `Number()`.

This changes the `execute` function to return `null` when appropriate.

A different solution would be to introduce a `node_const_null` node type, but I don't know if anything relies on null being `node_const`.