### PR TITLE
accept scientific notation for number tokens

### DIFF
--- a/src/grammar.jison
+++ b/src/grammar.jison
@@ -72,6 +72,7 @@
 \s+                                 /* ignore */
 [0-9]+\.[0-9]*|[0-9]*\.[0-9]+\b     return 'NUMBER'
 [0-9]+                              return 'NUMBER'
+[eE]"-"?[0-9]+                        return 'EXPONENT'
 
 
 '"'("\\"["]|[^"])*'"'				{ return 'STRING'; }
@@ -357,6 +358,7 @@ StringLiteral
 
 NumberLiteral
     : "NUMBER"                                                              { $$ = AST.createNode(lc(@1), 'node_const', parseFloat($1)); }
+    | "NUMBER" "EXPONENT"                                                   { $$ = AST.createNode(lc(@1), 'node_const', parseFloat($1 + $2)); }
     | "NAN"                                                                 { $$ = AST.createNode(lc(@1), 'node_const', NaN); }
     | "INFINITY"                                                            { $$ = AST.createNode(lc(@1), 'node_const', Infinity); }
     ;


### PR DESCRIPTION
JXG.Dump.toJessie just uses the built-in `toString` method for numbers, so sometimes they're rendered in scientific notation, e.g. "1.234e-17".

This changes the grammar to allow an exponent on the end of a number literal.

Numbers that start with a `.` still don't allow an exponent, because they look for a word boundary on the end. I'm not sure how best to fix this.