### PR TITLE
Compile without unnecessary parentheses 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 bin
-node_modules
 .idea/
+.DS_Store
+node_modules
+package-lock.json
+.vscode
+**/.vscode
+**/.vscode/*
+src/.vscode

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -944,8 +944,6 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
      * and compile the AST back to JessieCode with minimal number of parentheses.
      *
      * @param {String} code             JessieCode code to be parsed
-     * @param {Boolean} [geonext=false] Geonext compatibility mode.
-     * @param {Boolean} [dontstore=false] If false, the code string is stored in this.code.
      * @return {String}                 Simplified JessieCode code
      */
     simplify: function (code) {

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -1695,324 +1695,462 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
 
     /**
      * Compiles a parse tree back to JessieCode.
-     * @param {Object} node
+     * @param {Object} ast
      * @param {Boolean} [js=false] Compile either to JavaScript or back to JessieCode (required for the UI).
+     * @param {Boolean} [jcMinParens=false] When compiling to JessieCode, use minimal amount of parentheses?
      * @returns Something
      * @private
      */
-    compile: function (node, js) {
-        var e, i, list, scope,
-            ret = '';
+    compile: function (ast, js, jcMinParens) {
+        var that = this;
 
         if (!Type.exists(js)) {
             js = false;
         }
-
-        if (!node) {
-            return ret;
+        if (!Type.exists(jcMinParens)) {
+            jcMinParens = false;
         }
 
-        switch (node.type) {
-            case 'node_op':
-                switch (node.value) {
-                    case 'op_none':
-                        if (node.children[0]) {
-                            ret = this.compile(node.children[0], js);
-                        }
-                        if (node.children[1]) {
-                            ret += this.compile(node.children[1], js);
-                        }
-                        break;
-                    case 'op_block':
-                        ret = '{\n' + this.compile(node.children[0], js) + ' }\n';
-                        break;
-                    case 'op_assign':
-                        //e = this.compile(node.children[0], js);
-                        if (js) {
-                            e = this.getLHSCompiler(node.children[0], js);
-                            if (Type.isArray(e)) {
-                                ret = '$jc$.setProp(' + e[0] + ', ' + e[1] + ', ' + this.compile(node.children[1], js) + ');\n';
-                            } else {
-                                if (this.isLocalVariable(e) !== this.scope) {
-                                    this.scope.locals[e] = true;
-                                }
-                                ret = '$jc$.scopes[' + this.scope.id + '].locals[\'' + e + '\'] = ' + this.compile(node.children[1], js) + ';\n';
-                            }
-                        } else {
-                            e = this.compile(node.children[0]);
-                            ret = e + ' = ' + this.compile(node.children[1], js) + ';\n';
-                        }
-                        break;
-                    case 'op_if':
-                        ret = ' if (' + this.compile(node.children[0], js) + ') ' + this.compile(node.children[1], js);
-                        break;
-                    case 'op_if_else':
-                        ret = ' if (' + this.compile(node.children[0], js) + ')' + this.compile(node.children[1], js);
-                        ret += ' else ' + this.compile(node.children[2], js);
-                        break;
-                    case 'op_conditional':
-                        ret = '((' + this.compile(node.children[0], js) + ')?(' + this.compile(node.children[1], js);
-                        ret += '):(' + this.compile(node.children[2], js) + '))';
-                        break;
-                    case 'op_while':
-                        ret = ' while (' + this.compile(node.children[0], js) + ') {\n' + this.compile(node.children[1], js) + '}\n';
-                        break;
-                    case 'op_do':
-                        ret = ' do {\n' + this.compile(node.children[0], js) + '} while (' + this.compile(node.children[1], js) + ');\n';
-                        break;
-                    case 'op_for':
-                        //ret = ' for (' + this.compile(node.children[0], js) + '; ' + this.compile(node.children[1], js) + '; ' + this.compile(node.children[2], js) + ') {\n' + this.compile(node.children[3], js) + '\n}\n';
-                        ret = ' for (' + this.compile(node.children[0], js) +               // Assignment ends with ";"
-                            this.compile(node.children[1], js) + '; ' +         // Logical test comes without ";"
-                            this.compile(node.children[2], js).slice(0, -2) +   // Counting comes with ";" which has to be removed
-                            ') {\n' + this.compile(node.children[3], js) + '\n}\n';
-                        break;
-                    case 'op_proplst':
-                        if (node.children[0]) {
-                            ret = this.compile(node.children[0], js) + ', ';
-                        }
-
-                        ret += this.compile(node.children[1], js);
-                        break;
-                    case 'op_prop':
-                        // child 0: Identifier
-                        // child 1: Value
-                        ret = node.children[0] + ': ' + this.compile(node.children[1], js);
-                        break;
-                    case 'op_emptyobject':
-                        ret = js ? '{}' : '<< >>';
-                        break;
-                    case 'op_proplst_val':
-                        ret = this.compile(node.children[0], js);
-                        break;
-                    case 'op_array':
-                        list = [];
-                        for (i = 0; i < node.children[0].length; i++) {
-                            list.push(this.compile(node.children[0][i], js));
-                        }
-                        ret = '[' + list.join(', ') + ']';
-                        break;
-                    case 'op_extvalue':
-                        ret = this.compile(node.children[0], js) + '[' + this.compile(node.children[1], js) + ']';
-                        break;
-                    case 'op_return':
-                        ret = ' return ' + this.compile(node.children[0], js) + ';\n';
-                        break;
-                    case 'op_map':
-                        if (!node.children[1].isMath && node.children[1].type !== 'node_var') {
-                            this._error('compile: In a map only function calls and mathematical expressions are allowed.');
-                        }
-
-                        list = node.children[0];
-                        if (js) {
-                            ret = ' $jc$.makeMap(function (' + list.join(', ') + ') { return ' + this.compile(node.children[1], js) + '; })';
-                        } else {
-                            ret = 'map (' + list.join(', ') + ') -> ' + this.compile(node.children[1], js);
-                        }
-
-                        break;
-                    case 'op_function':
-                        list = node.children[0];
-                        scope = this.pushScope(list);
-                        if (js) {
-                            ret = this.functionCodeJS(node);
-                        } else {
-                            ret = ' function (' + list.join(', ') + ') ' + this.compile(node.children[1], js);
-                        }
-                        this.popScope();
-                        break;
-                    case 'op_execfunmath':
-                        console.log('op_execfunmath: TODO');
-                        ret = '-1';
-                        break;
-                    case 'op_execfun':
-                        // parse the properties only if given
-                        if (node.children[2]) {
-                            list = [];
-                            for (i = 0; i < node.children[2].length; i++) {
-                                list.push(this.compile(node.children[2][i], js));
-                            }
-
-                            if (js) {
-                                e = '$jc$.mergeAttributes(' + list.join(', ') + ')';
-                            } else {
-                                e = list.join(', ');
-                            }
-                        }
-                        node.children[0].withProps = !!node.children[2];
-                        list = [];
-                        for (i = 0; i < node.children[1].length; i++) {
-                            list.push(this.compile(node.children[1][i], js));
-                        }
-                        ret = this.compile(node.children[0], js) + '(' + list.join(', ') + (node.children[2] && js ? ', ' + e : '') + ')' + (node.children[2] && !js ? ' ' + e : '');
-                        if (js) {
-                            // Inserting a newline here allows simultaneously
-                            // - procedural calls like Q.moveTo(...); and
-                            // - function calls in expressions like log(x) + 1;
-                            // Problem: procedural calls will not be ended by a semicolon.
-                            ret += '\n';
-                        }
-
-                        // save us a function call when compiled to javascript
-                        if (js && node.children[0].value === '$') {
-                            ret = '$jc$.board.objects[' + this.compile(node.children[1][0], js) + ']';
-                        }
-                        break;
-                    case 'op_property':
-                        if (js && node.children[1] !== 'X' && node.children[1] !== 'Y') {
-                            ret = '$jc$.resolveProperty(' + this.compile(node.children[0], js) + ', \'' + node.children[1] + '\', true)';
-                        } else {
-                            ret = this.compile(node.children[0], js) + '.' + node.children[1];
-                        }
-                        break;
-                    case 'op_use':
-                        this._warn('Use of the \'use\' operator is deprecated.');
-                        if (js) {
-                            ret = '$jc$.use(\'';
-                        } else {
-                            ret = 'use(\'';
-                        }
-
-                        ret += node.children[0].toString() + '\');';
-                        break;
-                    case 'op_delete':
-                        this._warn('Use of the \'delete\' operator is deprecated. Please use the remove() function.');
-                        if (js) {
-                            ret = '$jc$.del(';
-                        } else {
-                            ret = 'remove(';
-                        }
-
-                        ret += this.compile(node.children[0], js) + ')';
-                        break;
-                    case 'op_eq':
-                        ret = '(' + this.compile(node.children[0], js) + ' === ' + this.compile(node.children[1], js) + ')';
-                        break;
-                    case 'op_neq':
-                        ret = '(' + this.compile(node.children[0], js) + ' !== ' + this.compile(node.children[1], js) + ')';
-                        break;
-                    case 'op_approx':
-                        ret = '(' + this.compile(node.children[0], js) + ' ~= ' + this.compile(node.children[1], js) + ')';
-                        break;
-                    case 'op_gt':
-                        if (js) {
-                            ret = '$jc$.gt(' + this.compile(node.children[0], js) + ', ' + this.compile(node.children[1], js) + ')';
-                        } else {
-                            ret = '(' + this.compile(node.children[0], js) + ' > ' + this.compile(node.children[1], js) + ')';
-                        }
-                        break;
-                    case 'op_lt':
-                        if (js) {
-                            ret = '$jc$.lt(' + this.compile(node.children[0], js) + ', ' + this.compile(node.children[1], js) + ')';
-                        } else {
-                            ret = '(' + this.compile(node.children[0], js) + ' < ' + this.compile(node.children[1], js) + ')';
-                        }
-                        break;
-                    case 'op_geq':
-                        if (js) {
-                            ret = '$jc$.geq(' + this.compile(node.children[0], js) + ', ' + this.compile(node.children[1], js) + ')';
-                        } else {
-                            ret = '(' + this.compile(node.children[0], js) + ' >= ' + this.compile(node.children[1], js) + ')';
-                        }
-                        break;
-                    case 'op_leq':
-                        if (js) {
-                            ret = '$jc$.leq(' + this.compile(node.children[0], js) + ', ' + this.compile(node.children[1], js) + ')';
-                        } else {
-                            ret = '(' + this.compile(node.children[0], js) + ' <= ' + this.compile(node.children[1], js) + ')';
-                        }
-                        break;
-                    case 'op_or':
-                        ret = '(' + this.compile(node.children[0], js) + ' || ' + this.compile(node.children[1], js) + ')';
-                        break;
-                    case 'op_and':
-                        ret = '(' + this.compile(node.children[0], js) + ' && ' + this.compile(node.children[1], js) + ')';
-                        break;
-                    case 'op_not':
-                        ret = '!(' + this.compile(node.children[0], js) + ')';
-                        break;
-                    case 'op_add':
-                        if (js) {
-                            ret = '$jc$.add(' + this.compile(node.children[0], js) + ', ' + this.compile(node.children[1], js) + ')';
-                        } else {
-                            ret = '(' + this.compile(node.children[0], js) + ' + ' + this.compile(node.children[1], js) + ')';
-                        }
-                        break;
-                    case 'op_sub':
-                        if (js) {
-                            ret = '$jc$.sub(' + this.compile(node.children[0], js) + ', ' + this.compile(node.children[1], js) + ')';
-                        } else {
-                            ret = '(' + this.compile(node.children[0], js) + ' - ' + this.compile(node.children[1], js) + ')';
-                        }
-                        break;
-                    case 'op_div':
-                        if (js) {
-                            ret = '$jc$.div(' + this.compile(node.children[0], js) + ', ' + this.compile(node.children[1], js) + ')';
-                        } else {
-                            ret = '(' + this.compile(node.children[0], js) + ' / ' + this.compile(node.children[1], js) + ')';
-                        }
-                        break;
-                    case 'op_mod':
-                        if (js) {
-                            ret = '$jc$.mod(' + this.compile(node.children[0], js) + ', ' + this.compile(node.children[1], js) + ', true)';
-                        } else {
-                            ret = '(' + this.compile(node.children[0], js) + ' % ' + this.compile(node.children[1], js) + ')';
-                        }
-                        break;
-                    case 'op_mul':
-                        if (js) {
-                            ret = '$jc$.mul(' + this.compile(node.children[0], js) + ', ' + this.compile(node.children[1], js) + ')';
-                        } else {
-                            ret = '(' + this.compile(node.children[0], js) + ' * ' + this.compile(node.children[1], js) + ')';
-                        }
-                        break;
-                    case 'op_exp':
-                        if (js) {
-                            ret = '$jc$.pow(' + this.compile(node.children[0], js) + ', ' + this.compile(node.children[1], js) + ')';
-                        } else {
-                            ret = '(' + this.compile(node.children[0], js) + '^' + this.compile(node.children[1], js) + ')';
-                        }
-                        break;
-                    case 'op_neg':
-                        if (js) {
-                            ret = '$jc$.neg(' + this.compile(node.children[0], js) + ')';
-                        } else {
-                            ret = '(-' + this.compile(node.children[0], js) + ')';
-                        }
-                        break;
-                }
-                break;
-
-            case 'node_var':
-                if (js) {
-                    ret = this.getvarJS(node.value, false, node.withProps);
-                } else {
-                    ret = node.value;
-                }
-                break;
-
-            case 'node_const':
-                ret = node.value;
-                break;
-
-            case 'node_const_bool':
-                ret = node.value;
-                break;
-
-            case 'node_str':
-                ret = '\'' + node.value + '\'';
-                break;
-        }
-
-        if (node.needsAngleBrackets) {
-            if (js) {
-                ret = '{\n' + ret + ' }\n';
-            } else {
-                ret = '<< ' + ret + ' >>\n';
+        // node_const/node_var >> op_execfun >> op_neg >> op_exp >> op_mul/op_div >> op_add/op_sub >> op_map >> op_assign
+        function prio(node) {
+            switch (node.type) {
+                case "node_const":
+                case "node_const_bool":
+                case "node_str":
+                case "node_var":
+                    return 10;
+                case "node_op":
+                    switch (node.value) {
+                        case "op_none":
+                            return 0;
+                        case "op_assign":
+                            return 1;
+                        case "op_map":
+                        case "op_function":
+                        case "op_return":
+                            return 2;
+                        case "op_add":
+                        case "op_sub":
+                            return 3;
+                        case "op_mul":
+                        case "op_div":
+                        case "op_mod":
+                            return 5;
+                        case "op_neg":
+                            return 4;
+                        case "op_exp":
+                            return 6;
+                        case "op_array":
+                        case "op_execfun":
+                            return 7;
+                        default:
+                            return 0;
+                    }
+                default:
+                    return 0;
             }
         }
 
-        return ret;
+        function compile(node, prevOp, position = -1) {
+            var e, i, list, scope, prioParent, prioChild,
+                ret = '';
+
+            if (!node) {
+                return ret;
+            }
+
+            switch (node.type) {
+                case 'node_op':
+                    switch (node.value) {
+                        case 'op_none':
+                            if (node.children[0]) {
+                                ret = compile(node.children[0], "op_none");
+                            }
+                            if (node.children[1]) {
+                                ret += compile(node.children[1], "op_none");
+                            }
+                            break;
+                        case 'op_block':
+                            ret = '{\n' + compile(node.children[0], "op_block") + ' }\n';
+                            break;
+                        case 'op_assign':
+                            if (js) {
+                                e = that.getLHSCompiler(node.children[0], js);
+                                if (Type.isArray(e)) {
+                                    ret = '$jc$.setProp(' + e[0] + ', ' + e[1] + ', ' + compile(node.children[1], "op_assign") + ');\n';
+                                } else {
+                                    if (that.isLocalVariable(e) !== that.scope) {
+                                        that.scope.locals[e] = true;
+                                    }
+                                    ret = '$jc$.scopes[' + that.scope.id + '].locals[\'' + e + '\'] = ' + compile(node.children[1], "op_assign") + ';\n';
+                                }
+                            } else {
+                                e = compile(node.children[0], "op_assign");
+                                ret = e + ' = ' + compile(node.children[1], "op_assign") + ';\n';
+                            }
+                            break;
+                        case 'op_if':
+                            ret = ' if (' + compile(node.children[0], "op_if") + ') ' + compile(node.children[1], "op_if");
+                            break;
+                        case 'op_if_else':
+                            ret = ' if (' + compile(node.children[0], "op_if_else") + ')' + compile(node.children[1], "op_if_else");
+                            ret += ' else ' + compile(node.children[2], "op_if_else");
+                            break;
+                        case 'op_conditional':
+                            ret = '((' + compile(node.children[0], "op_conditional") + ')?(' + compile(node.children[1], "op_conditional");
+                            ret += '):(' + compile(node.children[2], "op_conditional") + '))';
+                            break;
+                        case 'op_while':
+                            ret = ' while (' + compile(node.children[0], "op_while") + ') {\n' + compile(node.children[1], "op_while") + '}\n';
+                            break;
+                        case 'op_do':
+                            ret = ' do {\n' + compile(node.children[0], "op_do") + '} while (' + compile(node.children[1], "op_do") + ');\n';
+                            break;
+                        case 'op_for':
+                            //ret = ' for (' + compile(node.children[0]) + '; ' + compile(node.children[1]) + '; ' + compile(node.children[2]) + ') {\n' + compile(node.children[3]) + '\n}\n';
+                            ret = ' for (' + compile(node.children[0], "op_for") +   // Assignment ends with ";"
+                                compile(node.children[1], "op_for") + '; ' +         // Logical test comes without ";"
+                                compile(node.children[2], "op_for").slice(0, -2) +   // Counting comes with ";" which has to be removed
+                                ') {\n' + compile(node.children[3], "op_for") + '\n}\n';
+                            break;
+                        case 'op_proplst':
+                            if (node.children[0]) {
+                                ret = compile(node.children[0], "op_proplst") + ', ';
+                            }
+
+                            ret += compile(node.children[1], "op_proplst");
+                            break;
+                        case 'op_prop':
+                            // child 0: Identifier
+                            // child 1: Value
+                            ret = node.children[0] + ': ' + compile(node.children[1], "op_prop");
+                            break;
+                        case 'op_emptyobject':
+                            ret = js ? '{}' : '<< >>';
+                            break;
+                        case 'op_proplst_val':
+                            ret = compile(node.children[0], "op_proplst_val");
+                            break;
+                        case 'op_array':
+                            list = [];
+                            for (i = 0; i < node.children[0].length; i++) {
+                                list.push(compile(node.children[0][i], "op_array"));
+                            }
+                            ret = '[' + list.join(', ') + ']';
+                            break;
+                        case 'op_extvalue':
+                            ret = compile(node.children[0], "op_extvalue") + '[' + compile(node.children[1], "op_extvalue") + ']';
+                            break;
+                        case 'op_return':
+                            ret = ' return ' + compile(node.children[0], "op_return") + ';\n';
+                            break;
+                        case 'op_map':
+                            if (!node.children[1].isMath && node.children[1].type !== 'node_var') {
+                                that._error('compile: In a map only function calls and mathematical expressions are allowed.');
+                            }
+
+                            list = node.children[0];
+                            if (js) {
+                                ret = ' $jc$.makeMap(function (' + list.join(', ') + ') { return ' + compile(node.children[1], "op_map") + '; })';
+                            } else {
+                                ret = 'map (' + list.join(', ') + ') -> ' + compile(node.children[1], "op_map");
+                            }
+
+                            break;
+                        case 'op_function':
+                            list = node.children[0];
+                            scope = that.pushScope(list);
+                            if (js) {
+                                ret = that.functionCodeJS(node);
+                            } else {
+                                ret = ' function (' + list.join(', ') + ') ' + compile(node.children[1], "op_function");
+                            }
+                            that.popScope();
+                            break;
+                        case 'op_execfunmath':
+                            console.log('op_execfunmath: TODO');
+                            ret = '-1';
+                            break;
+                        case 'op_execfun':
+                            // parse the properties only if given
+                            if (node.children[2]) {
+                                list = [];
+                                for (i = 0; i < node.children[2].length; i++) {
+                                    list.push(compile(node.children[2][i], "op_execfun"));
+                                }
+
+                                if (js) {
+                                    e = '$jc$.mergeAttributes(' + list.join(', ') + ')';
+                                } else {
+                                    e = list.join(', ');
+                                }
+                            }
+                            node.children[0].withProps = !!node.children[2];
+                            list = [];
+                            for (i = 0; i < node.children[1].length; i++) {
+                                list.push(compile(node.children[1][i], "op_execfun"));
+                            }
+                            ret = compile(node.children[0], "op_execfun") + '(' + list.join(', ') + (node.children[2] && js ? ', ' + e : '') + ')' + (node.children[2] && !js ? ' ' + e : '');
+                            if (js) {
+                                // Inserting a newline here allows simultaneously
+                                // - procedural calls like Q.moveTo(...); and
+                                // - function calls in expressions like log(x) + 1;
+                                // Problem: procedural calls will not be ended by a semicolon.
+                                ret += '\n';
+                            }
+
+                            // save us a function call when compiled to javascript
+                            if (js && node.children[0].value === '$') {
+                                ret = '$jc$.board.objects[' + compile(node.children[1][0], "op_execfun") + ']';
+                            }
+                            break;
+                        case 'op_property':
+                            if (js && node.children[1] !== 'X' && node.children[1] !== 'Y') {
+                                ret = '$jc$.resolveProperty(' + compile(node.children[0], "op_property") + ', \'' + node.children[1] + '\', true)';
+                            } else {
+                                ret = compile(node.children[0], "op_property") + '.' + node.children[1];
+                            }
+                            break;
+                        case 'op_use':
+                            that._warn('Use of the \'use\' operator is deprecated.');
+                            if (js) {
+                                ret = '$jc$.use(\'';
+                            } else {
+                                ret = 'use(\'';
+                            }
+
+                            ret += node.children[0].toString() + '\');';
+                            break;
+                        case 'op_delete':
+                            that._warn('Use of the \'delete\' operator is deprecated. Please use the remove() function.');
+                            if (js) {
+                                ret = '$jc$.del(';
+                            } else {
+                                ret = 'remove(';
+                            }
+
+                            ret += compile(node.children[0], "op_delete") + ')';
+                            break;
+                        case 'op_eq':
+                            ret = '(' + compile(node.children[0], "op_eq") + ' === ' + compile(node.children[1], "op_eq") + ')';
+                            break;
+                        case 'op_neq':
+                            ret = '(' + compile(node.children[0], "op_neq") + ' !== ' + compile(node.children[1], "op_neq") + ')';
+                            break;
+                        case 'op_approx':
+                            ret = '(' + compile(node.children[0], "op_approx") + ' ~= ' + compile(node.children[1], "op_approx") + ')';
+                            break;
+                        case 'op_gt':
+                            if (js) {
+                                ret = '$jc$.gt(' + compile(node.children[0], "op_gt") + ', ' + compile(node.children[1], "op_gt") + ')';
+                            } else {
+                                ret = '(' + compile(node.children[0], "op_gt") + ' > ' + compile(node.children[1], "op_gt") + ')';
+                            }
+                            break;
+                        case 'op_lt':
+                            if (js) {
+                                ret = '$jc$.lt(' + compile(node.children[0], "op_lt") + ', ' + compile(node.children[1], "op_lt") + ')';
+                            } else {
+                                ret = '(' + compile(node.children[0], "op_lt") + ' < ' + compile(node.children[1], "op_lt") + ')';
+                            }
+                            break;
+                        case 'op_geq':
+                            if (js) {
+                                ret = '$jc$.geq(' + compile(node.children[0], "op_geq") + ', ' + compile(node.children[1], "op_geq") + ')';
+                            } else {
+                                ret = '(' + compile(node.children[0], "op_geq") + ' >= ' + compile(node.children[1], "op_geq") + ')';
+                            }
+                            break;
+                        case 'op_leq':
+                            if (js) {
+                                ret = '$jc$.leq(' + compile(node.children[0], "op_leq") + ', ' + compile(node.children[1], "op_leq") + ')';
+                            } else {
+                                ret = '(' + compile(node.children[0], "op_leq") + ' <= ' + compile(node.children[1], "op_leq") + ')';
+                            }
+                            break;
+                        case 'op_or':
+                            ret = '(' + compile(node.children[0], "op_or") + ' || ' + compile(node.children[1], "op_or") + ')';
+                            break;
+                        case 'op_and':
+                            ret = '(' + compile(node.children[0], "op_and") + ' && ' + compile(node.children[1], "op_and") + ')';
+                            break;
+                        case 'op_not':
+                            ret = '!(' + compile(node.children[0], "op_not") + ')';
+                            break;
+                        case "op_add":
+                            if (js) {
+                                ret = '$jc$.add(' + compile(node.children[0], "op_add") + ', ' + compile(node.children[1], "op_add") + ')';
+                            } else if (!jcMinParens) {
+                                ret = '(' + compile(node.children[0], "op_add") + ' + ' + compile(node.children[1], "op_add") + ')';
+                            } else {
+                                prioParent = prio(node);
+
+                                e = compile(node.children[0], "op_add");
+                                prioChild = prio(node.children[0]);
+                                ret = prioParent > prioChild ? "(" + e + ")" : e;
+
+                                ret += ' + ';
+
+                                e = compile(node.children[1], "op_add");
+                                prioChild = prio(node.children[1]);
+                                ret += prioParent > prioChild ? "(" + e + ")" : e;
+                            }
+                            break;
+                        case 'op_sub':
+                            if (js) {
+                                ret = '$jc$.sub(' + compile(node.children[0], "op_sub") + ', ' + compile(node.children[1], "op_sub") + ')';
+                            } else if (!jcMinParens) {
+                                ret = '(' + compile(node.children[0], "op_sub") + ' - ' + compile(node.children[1], "op_sub") + ')';
+                            } else {
+                                prioParent = prio(node);
+
+                                e = compile(node.children[0], "op_sub");
+                                prioChild = prio(node.children[0]);
+                                ret = prioParent > prioChild ? "(" + e + ")" : e;
+
+                                ret += ' - ';
+
+                                e = compile(node.children[1], "op_sub");
+                                prioChild = prio(node.children[1]);
+                                ret += prioParent >= prioChild ? "(" + e + ")" : e;
+                            }
+                            break;
+                        case 'op_div':
+                            if (js) {
+                                ret = '$jc$.div(' + compile(node.children[0], "op_div") + ', ' + compile(node.children[1], "op_div") + ')';
+                            } else if (!jcMinParens) {
+                                ret = '(' + compile(node.children[0], "op_div") + ' / ' + compile(node.children[1], "op_div") + ')';
+                            } else {
+                                prioParent = prio(node);
+
+                                e = compile(node.children[0], "op_div");
+                                prioChild = prio(node.children[0]);
+                                ret = prioParent > prioChild ? "(" + e + ")" : e;
+
+                                ret += ' / ';
+
+                                e = compile(node.children[1], "op_div");
+                                prioChild = prio(node.children[1]);
+                                ret += prioParent >= prioChild ? "(" + e + ")" : e;
+                            }
+                            break;
+                        case 'op_mod':
+                            if (js) {
+                                ret = '$jc$.mod(' + compile(node.children[0], "op_mod") + ', ' + compile(node.children[1], "op_mod") + ', true)';
+                            } else if (!jcMinParens) {
+                                ret = '(' + compile(node.children[0], "op_mod") + ' % ' + compile(node.children[1], "op_mod") + ')';
+                            } else {
+                                prioParent = prio(node);
+
+                                e = compile(node.children[0], "op_mod");
+                                prioChild = prio(node.children[0]);
+                                ret = prioParent > prioChild ? "(" + e + ")" : e;
+
+                                ret += ' % ';
+
+                                e = compile(node.children[1], "op_mod");
+                                prioChild = prio(node.children[1]);
+                                ret += prioParent >= prioChild ? "(" + e + ")" : e;
+                            }
+                            break;
+                        case 'op_mul':
+                            if (js) {
+                                ret = '$jc$.mul(' + compile(node.children[0], "op_mul") + ', ' + compile(node.children[1], "op_mul") + ')';
+                            } else if (!jcMinParens) {
+                                ret = '(' + compile(node.children[0], "op_mul") + ' * ' + compile(node.children[1], "op_mul") + ')';
+                            } else {
+                                prioParent = prio(node);
+
+                                e = compile(node.children[0], "op_mul");
+                                prioChild = prio(node.children[0]);
+                                ret = prioParent > prioChild ? "(" + e + ")" : e;
+
+                                ret += ' * ';
+
+                                e = compile(node.children[1], "op_mul");
+                                prioChild = prio(node.children[1]);
+                                ret += prioParent > prioChild ? "(" + e + ")" : e;
+                            }
+                            break;
+                        case 'op_exp':
+                            if (js) {
+                                ret = '$jc$.pow(' + compile(node.children[0], "op_exp") + ', ' + compile(node.children[1], "op_exp") + ')';
+                            } else if (!jcMinParens) {
+                                ret = '(' + compile(node.children[0], "op_exp") + '^' + compile(node.children[1], "op_exp") + ')';
+                            } else {
+                                prioParent = prio(node);
+
+                                e = compile(node.children[0], "op_exp");
+                                prioChild = prio(node.children[0]);
+                                ret = prioParent >= prioChild ? "(" + e + ")" : e;
+
+                                ret += '^';
+
+                                e = compile(node.children[1], "op_exp");
+                                prioChild = prio(node.children[1]);
+                                ret += prioParent > prioChild ? "(" + e + ")" : e;
+                            }
+                            break;
+                        case 'op_neg':
+                            if (js) {
+                                ret = '$jc$.neg(' + compile(node.children[0], "op_neg") + ')';
+                            } else if (!jcMinParens) {
+                                ret = '(-' + compile(node.children[0], "op_neg") + ')';
+                            } else {
+                                prioParent = prio(node);
+                                prioChild = prio(node.children[0]);
+                                e = compile(node.children[0], "op_neg");
+                                if (prioParent >= prioChild) {
+                                    ret = '-(' + e + ')';
+                                } else {
+                                    ret = '-' + e;
+                                }
+                            }
+                            break;
+                    }
+                    break;
+
+                case 'node_var':
+                    if (js) {
+                        ret = that.getvarJS(node.value, false, node.withProps);
+                    } else {
+                        ret = node.value;
+                    }
+                    break;
+
+                case 'node_const':
+                    if (js) {
+                        ret = node.value;
+                    } else {
+                        if (jcMinParens && parseFloat(node.value) < 0 && prevOp !== "op_execfun" && position !== 0) {
+                            ret = "(" + node.value + ")";
+                        } else {
+                            ret = node.value;
+                        }
+                    }
+                    break;
+
+                case 'node_const_bool':
+                    ret = node.value;
+                    break;
+
+                case 'node_str':
+                    ret = '\'' + node.value + '\'';
+                    break;
+            }
+
+            if (node.needsAngleBrackets) {
+                if (js) {
+                    ret = '{\n' + ret + ' }\n';
+                } else {
+                    ret = '<< ' + ret + ' >>\n';
+                }
+            }
+
+            return ret;
+        }
+
+        return compile(ast, "");
     },
 
     /**

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -879,6 +879,10 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
                         result = this.compile(ast);
                     }
                     break;
+                case 'minParens':
+                case 'minParentheses':
+                    result = this.compile(ast, false, true);
+                    break;
                 case 'getAst':
                     result = ast;
                     break;
@@ -942,6 +946,18 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
      */
     simplify: function (code) {
         return this._genericParse(code, 'simplify');
+    },
+
+    /**
+     * Manipulate JessieCode.
+     * This consists of generating an AST with parser.parse,
+     * and compile the AST back to JessieCode with minimal number of parentheses.
+     *
+     * @param {String} code             JessieCode code to be parsed
+     * @return {String}                 Simplified JessieCode code
+     */
+    minParentheses: function (code) {
+        return this._genericParse(code, 'minParentheses');
     },
 
     /**

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -811,18 +811,22 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
      * manipulate the AST according to the second parameter "cmd".
      * @param  {String} code      JessieCode code to be parsed
      * @param  {String} cmd       Type of manipulation to be done with AST
-     * @param {Boolean} [geonext=false] Geonext compatibility mode.
-     * @param {Boolean} [dontstore=false] If false, the code string is stored in this.code,
-     *  i.e. in the JessieCode object, e.g. in board.jc.
+     * @param {Object} [options]  Object with attributes <ul>
+     *     <li>{Boolean} [geonext=false]     Geonext compatibility mode.</li>
+     *     <li>{Boolean} [dontstore=false]   If false, the code string is stored in this.code, i.e. in the JessieCode object, e.g. in board.jc.</li>
+     *     </ul>
      * @return {Object} Returns result of computation as directed in cmd.
      */
-    _genericParse: function (code, cmd, geonext, dontstore) {
+    _genericParse: function (code, cmd, options) {
         var i, setTextBackup, ast, result,
             ccode = code.replace(/\r\n/g, '\n').split('\n'),
-            options = {},
             cleaned = [];
 
-        if (!dontstore) {
+        if (!Type.exists(options)) {
+            options = {};
+        }
+
+        if (!options.dontstore) {
             this.code += code + '\n';
         }
 
@@ -832,12 +836,12 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
         }
 
         try {
-            if (!Type.exists(geonext)) {
-                geonext = false;
+            if (!Type.exists(options.geonext)) {
+                options.geonext = false;
             }
 
             for (i = 0; i < ccode.length; i++) {
-                if (geonext) {
+                if (options.geonext) {
                     ccode[i] = JXG.GeonextParser.geonext2JS(ccode[i], this.board);
                 }
                 cleaned.push(ccode[i]);
@@ -915,7 +919,7 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
      * @return {Object}                 Parse JessieCode code and execute it.
      */
     parse: function (code, geonext, dontstore) {
-        return this._genericParse(code, 'parse', geonext, dontstore);
+        return this._genericParse(code, 'parse', {geonext: geonext, dontstore: dontstore});
     },
 
     /**
@@ -930,7 +934,7 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
      * @return {String}                 Simplified JessieCode code
      */
     manipulate: function (code, geonext, dontstore) {
-        return this._genericParse(code, 'manipulate', geonext, dontstore);
+        return this._genericParse(code, 'manipulate', {geonext: geonext, dontstore: dontstore});
     },
 
     /**
@@ -970,7 +974,7 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
      * @return {Node}  AST
      */
     getAST: function (code, geonext, dontstore) {
-        return this._genericParse(code, 'getAst', geonext, dontstore);
+        return this._genericParse(code, 'getAst', {geonext: geonext, dontstore: dontstore});
     },
 
     /**

--- a/test/testParse.js
+++ b/test/testParse.js
@@ -1,0 +1,70 @@
+/*
+    Copyright 2011-2012
+        Michael Gerhaeuser,
+        Alfred Wassermann,
+
+*/
+
+/*
+ *  Js-Test-Driver Test Suite for Generic JavaScript language tests
+ *  http://code.google.com/p/js-test-driver
+ */
+
+TestCase('Parser', {
+    jc: null,
+
+    setUp: function () {
+        this.jc = new JXG.JessieCode();
+    },
+
+    tearDown: function () {
+        this.jc = null;
+    },
+
+    testParse: function () {
+        var f = [
+            'function (x) { return ((((x + 3)^2) - 4.5) - 1.5); }',
+            'function (x) { return (sin((2^(x - 1))) + PI); }',
+        ], i, parsed;
+
+        expectAsserts(f.length);
+
+        for (i = 0; i < f.length; i++) {
+            try {
+                parsed = this.jc.parse(f[i] + ';');
+                parsed = parsed.toString().replaceAll('\n', '').trim();
+            } catch (e) {
+                console.log(e);
+            }
+            assertEquals('parse function ' + i, f[i], parsed);
+        }
+    },
+
+    testMinParentheses: function () {
+        var f = [
+            'function (x) { return (x + 3)^2 - 4.5 - 1.5; }',
+            'function (x) { return sin(2^(x - 1)) + PI; }',
+        ], i, parsed;
+
+        expectAsserts(f.length * 2);
+
+        for (i = 0; i < f.length; i++) {
+            try {
+                parsed = this.jc.minParentheses(f[i] + ';');
+                parsed = parsed.toString().replaceAll('\n', '').trim();
+            } catch (e) {
+                console.log(e);
+            }
+            assertEquals('minParentheses function ' + i, f[i], parsed);
+
+            try {
+                parsed = this.jc.parse(f[i] + ';');
+                parsed = parsed.toString().replaceAll('\n', '').trim();
+            } catch (e) {
+                console.log(e);
+            }
+            assertNotEquals('not minParentheses function ' + i, f[i], parsed); // parsed should contain more parentheses
+        }
+    },
+
+});


### PR DESCRIPTION
This pull request adds functionality to JessieCode that compiles an AST without unnecessary parentheses.

To achieve this, the following changes are made:
- New function `jc.minParentheses`
- New command `'minParentheses'` in `jc._genericParse`
- New parameter `jcMinParens` in the `jc.compile` function; its default value is false. This does not change anything in existing calls!
- In `jc.compile`:
    - Add parenthesis-avoidance functionality
    - Recursive sub-function `compile`.  `jc.compile` is no longer recursive itself. This eliminates the need to always "pass on" the parameters `js` and `jcMinParens`

Additionally:
- `_genericParse` now receives its attributes as an object (for future compatibility)
- Some documentation improvements
- Some JessieCode tests

No changes have been made to the existing functionality. The new functionality is only used when calling `board.jc.minParentheses` or `board.jc.compile(..., ..., true)`.