### PR TITLE
new function `format`

### DIFF
--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -973,20 +973,6 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
     },
 
     /**
-     * Manipulate JessieCode.
-     * This consists of generating an AST with parser.parse,
-     * and compile the AST back to JessieCode with minimal number of parentheses.
-     *
-     * @param {String} code             JessieCode code to be parsed
-     * @return {String}                 Simplified JessieCode code
-     * @deprecated
-     */
-    minParentheses: function (code) {
-        this._warn('Function \'minParentheses\' is deprecated. Please use \'format\' instead.');
-        return this._genericParse(code, 'format', {minParentheses: true});
-    },
-
-    /**
      * Get abstract syntax tree (AST) from JessieCode code.
      * This consists of generating an AST with parser.parse.
      *

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -836,12 +836,8 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
         }
 
         try {
-            if (!Type.exists(options.geonext)) {
-                options.geonext = false;
-            }
-
             for (i = 0; i < ccode.length; i++) {
-                if (options.geonext) {
+                if (!!options.geonext) {
                     ccode[i] = JXG.GeonextParser.geonext2JS(ccode[i], this.board);
                 }
                 cleaned.push(ccode[i]);

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -884,7 +884,7 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
                     }
                     break;
                 case 'format':
-                    result = this.compile(ast, false, options.minParentheses, options.constToFixed);
+                    result = this.compile(ast, false, options);
                     break;
                 case 'getAst':
                     result = ast;
@@ -1725,23 +1725,26 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
      * Compiles a parse tree back to JessieCode.
      * @param {Object} ast
      * @param {Boolean} [js=false] Compile either to JavaScript or back to JessieCode (required for the UI).
-     * @param {Boolean} [jcMinParens=false] When compiling to JessieCode, use minimal amount of parentheses?
-     * @param {Boolean|Number|Function} [constToFixed=false] When compiling to JessieCode, use this number or function to format constant values.
+     * @param {Object} [format] Options for formatting the output. Depending on some options, the function might return a not re-parsable string. This format options have only effect on JessieCode output.<ul>
+     *     <li>{Boolean} [minParentheses=false]               Use minimal amount of parentheses?</li>
+     *     <li>{Boolean|Number|Function} [constToFixed=false] Use this number or function to format constant values.</li>
+     *     </ul>
      * @returns Something
      * @private
      */
-    compile: function (ast, js, jcMinParens, constToFixed) {
+    compile: function (ast, js, format) {
         var that = this;
 
         if (!Type.exists(js)) {
             js = false;
         }
-        if (!Type.exists(jcMinParens)) {
-            jcMinParens = false;
+        if (!Type.exists(format) || !Type.isObject(format)) {
+            format = {};
         }
-        if (!Type.exists(constToFixed)) {
-            constToFixed = false;
-        }
+        format = Type.deepCopy({
+            minParentheses: false,
+            constToFixed: false
+        }, format);
 
         // node_const/node_var >> op_execfun >> op_neg >> op_exp >> op_mul/op_div >> op_add/op_sub >> op_map >> op_assign
         function prio(node) {
@@ -2012,7 +2015,7 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
                         case "op_add":
                             if (js) {
                                 ret = '$jc$.add(' + compile(node.children[0], "op_add") + ', ' + compile(node.children[1], "op_add") + ')';
-                            } else if (!jcMinParens) {
+                            } else if (!format.minParentheses) {
                                 ret = '(' + compile(node.children[0], "op_add") + ' + ' + compile(node.children[1], "op_add") + ')';
                             } else {
                                 prioParent = prio(node);
@@ -2031,7 +2034,7 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
                         case 'op_sub':
                             if (js) {
                                 ret = '$jc$.sub(' + compile(node.children[0], "op_sub") + ', ' + compile(node.children[1], "op_sub") + ')';
-                            } else if (!jcMinParens) {
+                            } else if (!format.minParentheses) {
                                 ret = '(' + compile(node.children[0], "op_sub") + ' - ' + compile(node.children[1], "op_sub") + ')';
                             } else {
                                 prioParent = prio(node);
@@ -2050,7 +2053,7 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
                         case 'op_div':
                             if (js) {
                                 ret = '$jc$.div(' + compile(node.children[0], "op_div") + ', ' + compile(node.children[1], "op_div") + ')';
-                            } else if (!jcMinParens) {
+                            } else if (!format.minParentheses) {
                                 ret = '(' + compile(node.children[0], "op_div") + ' / ' + compile(node.children[1], "op_div") + ')';
                             } else {
                                 prioParent = prio(node);
@@ -2069,7 +2072,7 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
                         case 'op_mod':
                             if (js) {
                                 ret = '$jc$.mod(' + compile(node.children[0], "op_mod") + ', ' + compile(node.children[1], "op_mod") + ', true)';
-                            } else if (!jcMinParens) {
+                            } else if (!format.minParentheses) {
                                 ret = '(' + compile(node.children[0], "op_mod") + ' % ' + compile(node.children[1], "op_mod") + ')';
                             } else {
                                 prioParent = prio(node);
@@ -2088,7 +2091,7 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
                         case 'op_mul':
                             if (js) {
                                 ret = '$jc$.mul(' + compile(node.children[0], "op_mul") + ', ' + compile(node.children[1], "op_mul") + ')';
-                            } else if (!jcMinParens) {
+                            } else if (!format.minParentheses) {
                                 ret = '(' + compile(node.children[0], "op_mul") + ' * ' + compile(node.children[1], "op_mul") + ')';
                             } else {
                                 prioParent = prio(node);
@@ -2107,7 +2110,7 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
                         case 'op_exp':
                             if (js) {
                                 ret = '$jc$.pow(' + compile(node.children[0], "op_exp") + ', ' + compile(node.children[1], "op_exp") + ')';
-                            } else if (!jcMinParens) {
+                            } else if (!format.minParentheses) {
                                 ret = '(' + compile(node.children[0], "op_exp") + '^' + compile(node.children[1], "op_exp") + ')';
                             } else {
                                 prioParent = prio(node);
@@ -2126,7 +2129,7 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
                         case 'op_neg':
                             if (js) {
                                 ret = '$jc$.neg(' + compile(node.children[0], "op_neg") + ')';
-                            } else if (!jcMinParens) {
+                            } else if (!format.minParentheses) {
                                 ret = '(-' + compile(node.children[0], "op_neg") + ')';
                             } else {
                                 prioParent = prio(node);
@@ -2157,18 +2160,18 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
                     }
 
                     c = node.value;
-                    if (constToFixed !== false && Type.isNumber(c) && (prevOp !== 'op_exp' || Math.round(c) - c !== 0)) {
+                    if (format.constToFixed !== false && Type.isNumber(c) && (prevOp !== "op_exp" || Math.round(c) - c !== 0)) {
                         c = parseFloat(c);
-                        if (Type.isNumber(constToFixed)) {
-                            c = Type.toFixed(c, constToFixed);
-                        } else if (Type.isFunction(constToFixed)) {
-                            c = constToFixed(c);
+                        if (Type.isNumber(format.constToFixed)) {
+                            c = Type.toFixed(c, format.constToFixed);
+                        } else if (Type.isFunction(format.constToFixed)) {
+                            c = format.constToFixed(c);
                         } else {
                             c = node.value;
                         }
                     }
-                    if (jcMinParens && parseFloat(c) < 0 && prevOp !== 'op_execfun' && position !== 0) {
-                        ret = '(' + c + ')';
+                    if (format.minParentheses && parseFloat(c) < 0 && prevOp !== "op_execfun" && position !== 0) {
+                        ret = "(" + c + ")";
                     } else {
                         ret = c;
                     }

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -1714,6 +1714,7 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
      * @param {Object} [format] Options for formatting the output. Depending on some options, the function might return a not re-parsable string. This format options have only effect on JessieCode output.<ul>
      *     <li>{Boolean} [minParentheses=false]               Use minimal amount of parentheses?</li>
      *     <li>{Boolean|Number|Function} [constToFixed=false] Use this number or function to format constant values.</li>
+     *     <li>{Boolean} [printable=false]                    Adds additional signs or parentheses, e.g. x^0.5 --> x^{0.5}.</li>
      *     </ul>
      * @returns Something
      * @private
@@ -1729,7 +1730,8 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
         }
         format = Type.deepCopy({
             minParentheses: false,
-            constToFixed: false
+            constToFixed: false,
+            printable: false
         }, format);
 
         // node_const/node_var >> op_execfun >> op_neg >> op_exp >> op_mul/op_div >> op_add/op_sub >> op_map >> op_assign
@@ -2095,19 +2097,19 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
                             break;
                         case 'op_exp':
                             if (js) {
-                                ret = '$jc$.pow(' + compile(node.children[0], "op_exp") + ', ' + compile(node.children[1], "op_exp") + ')';
+                                ret = '$jc$.pow(' + compile(node.children[0], "op_exp", 0) + ', ' + compile(node.children[1], "op_exp", 1) + ')';
                             } else if (!format.minParentheses) {
-                                ret = '(' + compile(node.children[0], "op_exp") + '^' + compile(node.children[1], "op_exp") + ')';
+                                ret = '(' + compile(node.children[0], "op_exp", 0) + '^' + compile(node.children[1], "op_exp", 1) + ')';
                             } else {
                                 prioParent = prio(node);
 
-                                e = compile(node.children[0], "op_exp");
+                                e = compile(node.children[0], "op_exp", 0);
                                 prioChild = prio(node.children[0]);
                                 ret = prioParent >= prioChild ? "(" + e + ")" : e;
 
                                 ret += '^';
 
-                                e = compile(node.children[1], "op_exp");
+                                e = compile(node.children[1], "op_exp", 1);
                                 prioChild = prio(node.children[1]);
                                 ret += prioParent > prioChild ? "(" + e + ")" : e;
                             }
@@ -2146,7 +2148,11 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
                     }
 
                     c = node.value;
-                    if (format.constToFixed !== false && Type.isNumber(c) && (prevOp !== "op_exp" || Math.round(c) - c !== 0)) {
+                    if (
+                        format.constToFixed !== false &&
+                        Type.isNumber(c) &&
+                        !(prevOp === "op_exp" && position === 1) // exponents will not be formatted
+                    ) {
                         c = parseFloat(c);
                         if (Type.isNumber(format.constToFixed)) {
                             c = Type.toFixed(c, format.constToFixed);
@@ -2178,6 +2184,14 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
                 } else {
                     ret = '<< ' + ret + ' >>\n';
                 }
+            }
+
+            if (format.printable && prevOp === "op_exp" && position === 1) {
+                ret = '{' + ret + '}';
+            }
+
+            if (format.printable && Type.isString(ret)) {
+                ret = ret.replaceAll('\n', '');
             }
 
             return ret;

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -949,23 +949,13 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
      * Format JessieCode.
      * This consists of generating an AST with parser.parse,
      * and compile the AST back to JessieCode with options.
-     * This function might return not a re-parsable JessieCode code!
      *
-     * @param {String} code             JessieCode code to be parsed
-     * @param {Object} options          <ul>
-     *     <li>{Boolean} [minParentheses=false]         Use minimal number of parentheses.</li>
-     *     <li>{Number|Function} [constToFixed=false]   Format constant numbers with fixed amount of digits.</li>
-     *     </ul>
-     * @return {String}                 Manipulated JessieCode string. This is no necessarily a parsable JessieCode code!
+     * @param {String} code      JessieCode code to be parsed.
+     * @param {Object} options   For possible options see param "format" in {@link JXG.JessieCode#compile}.
+     * @return {String}          Manipulated JessieCode string. This is no necessarily a parsable JessieCode code!
      */
     format: function (code, options) {
-        var opt = {};
-
-        // For security. Remove the following lines to allow every options object.
-        opt.minParentheses = options.minParentheses;
-        opt.constToFixed = options.constToFixed;
-
-        return this._genericParse(code, 'format', opt);
+        return this._genericParse(code, 'format', options);
     },
 
     /**

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -883,9 +883,8 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
                         result = this.compile(ast);
                     }
                     break;
-                case 'minParens':
-                case 'minParentheses':
-                    result = this.compile(ast, false, true);
+                case 'format':
+                    result = this.compile(ast, false, options.minParentheses, options.constToFixed);
                     break;
                 case 'getAst':
                     result = ast;
@@ -951,15 +950,40 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
     },
 
     /**
+     * Format JessieCode.
+     * This consists of generating an AST with parser.parse,
+     * and compile the AST back to JessieCode with options.
+     * This function might return not a re-parsable JessieCode code!
+     *
+     * @param {String} code             JessieCode code to be parsed
+     * @param {Object} options          <ul>
+     *     <li>{Boolean} [minParentheses=false]         Use minimal number of parentheses.</li>
+     *     <li>{Number|Function} [constToFixed=false]   Format constant numbers with fixed amount of digits.</li>
+     *     </ul>
+     * @return {String}                 Manipulated JessieCode string. This is no necessarily a parsable JessieCode code!
+     */
+    format: function (code, options) {
+        var opt = {};
+
+        // For security. Remove the following lines to allow every options object.
+        opt.minParentheses = options.minParentheses;
+        opt.constToFixed = options.constToFixed;
+
+        return this._genericParse(code, 'format', opt);
+    },
+
+    /**
      * Manipulate JessieCode.
      * This consists of generating an AST with parser.parse,
      * and compile the AST back to JessieCode with minimal number of parentheses.
      *
      * @param {String} code             JessieCode code to be parsed
      * @return {String}                 Simplified JessieCode code
+     * @deprecated
      */
     minParentheses: function (code) {
-        return this._genericParse(code, 'minParentheses');
+        this._warn('Function \'minParentheses\' is deprecated. Please use \'format\' instead.');
+        return this._genericParse(code, 'format', {minParentheses: true});
     },
 
     /**
@@ -1716,10 +1740,11 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
      * @param {Object} ast
      * @param {Boolean} [js=false] Compile either to JavaScript or back to JessieCode (required for the UI).
      * @param {Boolean} [jcMinParens=false] When compiling to JessieCode, use minimal amount of parentheses?
+     * @param {Boolean|Number|Function} [constToFixed=false] When compiling to JessieCode, use this number or function to format constant values.
      * @returns Something
      * @private
      */
-    compile: function (ast, js, jcMinParens) {
+    compile: function (ast, js, jcMinParens, constToFixed) {
         var that = this;
 
         if (!Type.exists(js)) {
@@ -1727,6 +1752,9 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
         }
         if (!Type.exists(jcMinParens)) {
             jcMinParens = false;
+        }
+        if (!Type.exists(constToFixed)) {
+            constToFixed = false;
         }
 
         // node_const/node_var >> op_execfun >> op_neg >> op_exp >> op_mul/op_div >> op_add/op_sub >> op_map >> op_assign
@@ -1770,7 +1798,7 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
         }
 
         function compile(node, prevOp, position = -1) {
-            var e, i, list, scope, prioParent, prioChild,
+            var e, i, c, list, scope, prioParent, prioChild,
                 ret = '';
 
             if (!node) {
@@ -2139,12 +2167,24 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
                 case 'node_const':
                     if (js) {
                         ret = node.value;
-                    } else {
-                        if (jcMinParens && parseFloat(node.value) < 0 && prevOp !== "op_execfun" && position !== 0) {
-                            ret = "(" + node.value + ")";
+                        break;
+                    }
+
+                    c = node.value;
+                    if (constToFixed !== false && Type.isNumber(c) && (prevOp !== 'op_exp' || Math.round(c) - c !== 0)) {
+                        c = parseFloat(c);
+                        if (Type.isNumber(constToFixed)) {
+                            c = Type.toFixed(c, constToFixed);
+                        } else if (Type.isFunction(constToFixed)) {
+                            c = constToFixed(c);
                         } else {
-                            ret = node.value;
+                            c = node.value;
                         }
+                    }
+                    if (jcMinParens && parseFloat(c) < 0 && prevOp !== 'op_execfun' && position !== 0) {
+                        ret = '(' + c + ')';
+                    } else {
+                        ret = c;
                     }
                     break;
 


### PR DESCRIPTION
Via options the function allows:
- to minify parentheses in a JessieCode code
- format constant nodes to a fixed number of digits
- create a printable output (e.g. `x^0.5` --> `x^{0.5}`)

This function replaces the function and cmd `minParentheses`., so this function was removed.

Additional params of `compile` were combined to one object `format`, so it can be easily extended. This has no effect to old usages, because the third param was added just recently.  
Depending on some options, the function might return a not re-parsable string. But with default param `{}` this will not happen.