### PR TITLE
execute `op_block` nodes

### DIFF
--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -1384,6 +1384,9 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
                             ret = this.execute(node.children[1]);
                         }
                         break;
+                    case 'op_block':
+                        this.execute(node.children[0]);
+                        break;
                     case 'op_assign':
                         v = this.getLHS(node.children[0]);
                         this.lhs[this.scope.id] = v.what;


### PR DESCRIPTION
The commit 8bbcc2a473812ebac2fc6d30a808352fbab4441b added an `op_block` node, for blocks of code inside curly braces. A case was added to the `compile` function, but no corresponding case was added to the `execute` function, so blocks of code just aren't executed any more.

So code like this:

```
if(true) {
    point(0,0);
}
```

would produce nothing, instead of a point at the origin.

I think that just executing the single child node is all that needs to happen.